### PR TITLE
Upgrade Scala versions, add 2.13.1 to crossScalaVersions

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,8 +5,8 @@ object BuildSettings {
   val buildSettings = Defaults.defaultSettings ++ Seq (
     organization  := "com.softwaremill.scalamacrodebug",
     version       := "0.4.1",
-    scalaVersion  := "2.11.8",
-    crossScalaVersions := List(scalaVersion.value, "2.12.1"),
+    scalaVersion  := "2.11.12",
+    crossScalaVersions := List(scalaVersion.value, "2.12.10", "2.13.1"),
     // Sonatype OSS deployment
     publishTo <<= version { (v: String) =>
       val nexus = "https://oss.sonatype.org/"


### PR DESCRIPTION
Hi.

We are, in fact, still using this library and wanted to switch to Scala 2.13.

Could you publish a new version please... :smile_cat: 

Thanks!